### PR TITLE
Introduce timeout for initial connection

### DIFF
--- a/homcc/client/client.py
+++ b/homcc/client/client.py
@@ -104,7 +104,7 @@ class TCPClient:
         logger.debug("Connecting to %s:%i", self.host, self.port)
         self._reader, self._writer = await asyncio.wait_for(
             asyncio.open_connection(host=self.host, port=self.port, limit=self.buffer_limit),
-            timeout=self.DEFAULT_OPEN_CONNECTION_TIMEOUT
+            timeout=self.DEFAULT_OPEN_CONNECTION_TIMEOUT,
         )
         return self
 


### PR DESCRIPTION
This PR introduced timeouting on trying to open a new connection.
Before this change we would have waited the full 180s compilation timeout period when the server was not reachable instead of the 5s timeout now.