### PR TITLE
Fix Workflow Stale apt index

### DIFF
--- a/.github/workflows/build-branch.yml
+++ b/.github/workflows/build-branch.yml
@@ -24,8 +24,8 @@ jobs:
           cache: 'pip'
       - name: Install dependencies
         run: |
-          sudo apt update
-          sudo apt install liblzo2-dev
+          sudo apt-get update
+          sudo apt-get install liblzo2-dev
           python -m pip install --upgrade pip
           pip install -r requirements.txt
       - name: Execute linters
@@ -44,8 +44,8 @@ jobs:
           cache: 'pip'
       - name: Install dependencies
         run: |
-          sudo apt update
-          sudo apt install liblzo2-dev
+          sudo apt-get update
+          sudo apt-get install liblzo2-dev
           python -m pip install --upgrade pip
           pip install -r requirements.txt
       - name: Execute format-check
@@ -64,8 +64,8 @@ jobs:
           cache: 'pip'
       - name: Install dependencies
         run: |
-          sudo apt update
-          sudo apt install liblzo2-dev
+          sudo apt-get update
+          sudo apt-get install liblzo2-dev
           python -m pip install --upgrade pip
           pip install -r requirements.txt
       - name: Run tests

--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -21,8 +21,8 @@ jobs:
           cache: 'pip'
       - name: Install dependencies
         run: |
-          sudo apt update
-          sudo apt install liblzo2-dev
+          sudo apt-get update
+          sudo apt-get install liblzo2-dev
           python -m pip install --upgrade pip
           pip install -r requirements.txt
       - name: Execute linters
@@ -41,8 +41,8 @@ jobs:
           cache: 'pip'
       - name: Install dependencies
         run: |
-          sudo apt update
-          sudo apt install liblzo2-dev
+          sudo apt-get update
+          sudo apt-get install liblzo2-dev
           python -m pip install --upgrade pip
           pip install -r requirements.txt
       - name: Execute format-check
@@ -61,15 +61,15 @@ jobs:
           cache: 'pip'
       - name: Install dependencies
         run: |
-          sudo apt update
-          sudo apt install liblzo2-dev schroot debootstrap
+          sudo apt-get update
+          sudo apt-get install liblzo2-dev schroot debootstrap
           python -m pip install --upgrade pip
           pip install -r requirements.txt
       - name: Setup chroot environment
         run: |
           sudo debootstrap focal /var/chroot/focal http://archive.ubuntu.com/ubuntu
           sudo ./.github/setup_chroot_env.sh focal $(id -nG | sed 's/ /,/g')
-          sudo schroot -c focal -- apt -y install g++
+          sudo schroot -c focal -- apt-get -y install g++
       - name: Run tests
         run: pytest -v -rfE --cov=homcc --capture=tee-sys --runschroot=focal
   build:
@@ -79,8 +79,8 @@ jobs:
         uses: actions/checkout@v2
       - name: Install packaging dependencies # see https://github.com/astraw/stdeb/issues/175
         run: |
-          sudo apt update
-          sudo apt install -y \
+          sudo apt-get update
+          sudo apt-get install -y \
             python3 python3-dev python3-pip python3-venv python3-all \
             dh-python debhelper devscripts dput software-properties-common \
             python3-distutils python3-setuptools python3-wheel python3-stdeb \


### PR DESCRIPTION
Execute `apt update`s before every `apt install` as recommended [here](https://docs.github.com/en/actions/using-github-hosted-runners/customizing-github-hosted-runners#installing-software-on-ubuntu-runners) to fix the current `main` branch building.