### PR TITLE
Limit the lifetime of rogue processes

### DIFF
--- a/homcc/common/arguments.py
+++ b/homcc/common/arguments.py
@@ -35,6 +35,9 @@ class Arguments:
     compilation which implies arguments being able to be sent!
     """
 
+    # execution timeout
+    TIMEOUT: int = 180
+
     # if the compiler is neither specified by the callee nor defined in the config file use this as fallback
     DEFAULT_COMPILER: str = "cc"
     PREPROCESSOR_TARGET: str = "$(homcc)"
@@ -486,7 +489,7 @@ class Arguments:
         logger.debug("Executing: [%s]", " ".join(args))
 
         result: subprocess.CompletedProcess = subprocess.run(
-            args=args, check=check, encoding="utf-8", capture_output=capture_output, **kwargs
+            args=args, check=check, encoding="utf-8", capture_output=capture_output, timeout=Arguments.TIMEOUT, **kwargs
         )
         return ArgumentsExecutionResult.from_process_result(result)
 


### PR DESCRIPTION
This PR will limit the lifetime of rogue compilation processes on the server (and theoretically also on the client), that will over time lead to an inevitable `Not accepting new connection, as max limit of #X connections is already reached.` soft lock.
The fix itself simply compensates the effects of an underlying issue but does not yet solve it. While intended as a temporary solution, I still think having a general timeout on compilation processes in the future remains beneficial.