### PR TITLE
Safeguard against recursive client calls

### DIFF
--- a/homcc/client/main.py
+++ b/homcc/client/main.py
@@ -40,21 +40,22 @@ from homcc.common.logging import (  # pylint: disable=wrong-import-position
 
 logger: logging.Logger = logging.getLogger(__name__)
 
-HOMCC_SAFEGUARD: str = "_HOMCC_SAFEGUARD"
+HOMCC_SAFEGUARD_ENV_VAR: str = "_HOMCC_SAFEGUARD"
 
 
-def is_recursively_called() -> bool:
+def is_recursively_invoked() -> bool:
     """Check whether homcc was called recursively by checking the existence of a safeguard environment variable"""
 
-    was_already_called: bool = HOMCC_SAFEGUARD in os.environ
-    os.environ[HOMCC_SAFEGUARD] = "1"
-    return was_already_called
+    is_safeguard_active: bool = HOMCC_SAFEGUARD_ENV_VAR in os.environ
+    os.environ[HOMCC_SAFEGUARD_ENV_VAR] = "1"  # activate safeguard
+    return is_safeguard_active
 
 
 def main():
-    # cancel execution if recursion was detected
-    if is_recursively_called():
-        raise SystemExit(f"{sys.argv[0]} seems to have invoked itself recursively!")
+    # cancel execution if recursive call is detected
+    if is_recursively_invoked():
+        print(f"{sys.argv[0]} seems to have been invoked recursively!", file=sys.stderr)
+        raise SystemExit(os.EX_USAGE)
 
     # load and parse arguments and configuration information
     homcc_args_dict, compiler_arguments = parse_cli_args(sys.argv[1:])

--- a/tests/e2e/e2e_test.py
+++ b/tests/e2e/e2e_test.py
@@ -253,6 +253,19 @@ class TestEndToEnd:
         Path("foo.o").unlink(missing_ok=True)
         Path(self.OUTPUT).unlink(missing_ok=True)
 
+    @pytest.mark.timeout(TIMEOUT)
+    def test_end_to_end_recursive_client(self, unused_tcp_port: int):
+        try:
+            subprocess.run(  # client receiving itself as compiler arg
+                self.BasicClientArguments("./homcc/client/main.py", unused_tcp_port).to_list(),
+                check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                encoding="utf-8",
+            )
+        except subprocess.CalledProcessError as err:
+            assert "seems to have been invoked recursively!" in err.stdout
+
     # g++ tests
     @pytest.mark.gplusplus
     @pytest.mark.timeout(TIMEOUT)


### PR DESCRIPTION
Add detection for a recursive calls, e.g.:
```sh
$ homcc homcc
[HOMCC-ERROR] Compiler error:
/usr/bin/homcc seems to have invoked itself recursively!
```
I want to include the recursion check as early as possible so I added a preliminary `e2e` test.
`distcc` provides more sophisticated **masquerading** but, for now, this check should prevent errors early.