### PR TITLE
Increase client compilation timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ Additionally, `HOMCC` provides sandboxed compiler execution for remote compilati
     <td><sub><pre lang="ini">
     [homcc]
     compiler=g++
-    timeout=60
+    timeout=120
     compression=lzo
     schroot_profile=jammy
     docker_container=example_container

--- a/homcc/client/compilation.py
+++ b/homcc/client/compilation.py
@@ -39,7 +39,7 @@ from homcc.common.messages import (
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_COMPILATION_REQUEST_TIMEOUT: float = 60
+DEFAULT_COMPILATION_REQUEST_TIMEOUT: float = 120
 DEFAULT_LOCALHOST_LIMIT: int = (
     len(os.sched_getaffinity(0))  # number of available CPUs for this process
     or os.cpu_count()  # total number of physical CPUs on the machine


### PR DESCRIPTION
We saw some issues with timeouting too early (especially when compiling with >60 threads).
Therefore this PR doubles the default timeout value from 60secs to 120secs to give the server enough time to compile and transmit the object file back.