### PR TITLE
Also map macros to correct paths

### DIFF
--- a/homcc/common/arguments.py
+++ b/homcc/common/arguments.py
@@ -44,24 +44,6 @@ class Arguments:
 
     NO_LINKING_ARG: str = "-c"
 
-    # for gcc, see https://gcc.gnu.org/onlinedocs/gcc/Debugging-Options.html#Debugging-Options
-    # for clang, see https://clang.llvm.org/docs/ClangCommandLineReference.html#debug-information-generation
-    DEBUG_SYMBOLS_ARGS: List[str] = [
-        "-g",
-        "-ggdb",
-        "-gdwarf",
-        "-gfull",
-        "--debug",
-        "-gused" "-gbtf",
-        "-gctf",
-        "-gstabs",
-        "-gstabs+",
-        "-gxcoff",
-        "-gxcoff+",
-        "-gvms",
-    ]
-    DEBUG_SYMBOLS_WITH_LEVEL: List[str] = ["-g", "-ggdb", "-gdwarf-", "-gctf", "-gstabs", "-gxcoff", "-gvms"]
-
     OUTPUT_ARG: str = "-o"
     SPECIFY_LANGUAGE_ARG: str = "-x"
 
@@ -434,23 +416,11 @@ class Arguments:
         """check whether the linking arg is present"""
         return self.NO_LINKING_ARG not in self.args
 
-    def has_debug_symbols(self) -> bool:
-        """check whether any flag that indicates debug symbols is present"""
-        for arg in self.args:
-            if arg in self.DEBUG_SYMBOLS_ARGS:
-                # debug arguments without level, e.g. -g or -ggdb
-                return True
-
-            for debug_symbol_flag in self.DEBUG_SYMBOLS_WITH_LEVEL:
-                # recognize arguments like e.g. -g3 or -ggdb2
-                if arg.startswith(debug_symbol_flag) and len(arg) == len(debug_symbol_flag) + 1 and arg[-1].isdigit():
-                    return True
-
-        return False
-
-    def map_debug_symbol_paths(self, old_path: str, new_path: str) -> Arguments:
-        """return a copy of arguments with added command for translating debug symbol paths in the executable"""
-        return self.copy().add_arg(f"-fdebug-prefix-map={old_path}={new_path}")
+    def map_symbol_paths(self, old_path: str, new_path: str) -> Arguments:
+        """return a copy of arguments with added command for translating symbol paths in the executable
+        See https://reproducible-builds.org/docs/build-path/.
+        This maps debug symbols as well as macros such as __FILE__."""
+        return self.copy().add_arg(f"-ffile-prefix-map={old_path}={new_path}")
 
     def is_linking_only(self) -> bool:
         """check whether the execution of arguments leads to calling only the linker"""

--- a/homcc/server/environment.py
+++ b/homcc/server/environment.py
@@ -143,8 +143,7 @@ class Environment:
         # create the mapped current working directory if it doesn't exist yet
         Path(self.mapped_cwd).mkdir(parents=True, exist_ok=True)
 
-        if arguments.has_debug_symbols():
-            arguments = arguments.map_debug_symbol_paths(self.instance_folder, "")
+        arguments = arguments.map_symbol_paths(self.instance_folder, "")
 
         result = self.invoke_compiler(arguments.no_linking())
 

--- a/tests/common/arguments_test.py
+++ b/tests/common/arguments_test.py
@@ -246,31 +246,6 @@ class TestArguments:
 
         assert Arguments.from_args(args).source_files == source_file_args
 
-    def test_has_debug_symbols_arg(self):
-        args = ["g++", "-g", "foo.cpp"]
-        assert Arguments.from_args(args).has_debug_symbols()
-
-        args = ["g++", "-g3", "foo.cpp"]
-        assert Arguments.from_args(args).has_debug_symbols()
-
-        args = ["g++", "-g", "3", "foo.cpp"]
-        assert Arguments.from_args(args).has_debug_symbols()
-
-        args = ["g++", "-ggdb", "foo.cpp"]
-        assert Arguments.from_args(args).has_debug_symbols()
-
-        args = ["g++", "-ggdb2", "foo.cpp"]
-        assert Arguments.from_args(args).has_debug_symbols()
-
-        args = ["g++", "-gdwarf", "foo.cpp"]
-        assert Arguments.from_args(args).has_debug_symbols()
-
-        args = ["g++", "-gdwarf-2", "foo.cpp"]
-        assert Arguments.from_args(args).has_debug_symbols()
-
-        args = ["g++", "-Iinclude", "foo.cpp"]
-        assert not Arguments.from_args(args).has_debug_symbols()
-
     def test_compiler_normalized(self):
         assert Arguments.from_args(["gcc", "foo"]).compiler_normalized() == "gcc"
         assert Arguments.from_args(["/usr/bin/gcc", "foo"]).compiler_normalized() == "gcc"

--- a/tests/server/environment_test.py
+++ b/tests/server/environment_test.py
@@ -179,7 +179,7 @@ class TestServerCompilation:
         assert len(result_message.object_files) == 1
         assert result_message.object_files[0].file_name == "/home/user/cwd/this_is_a_source_file.o"
 
-    def test_debug_symbol_mappings(self, mocker: MockerFixture):
+    def test_symbol_mappings(self, mocker: MockerFixture):
         invoke_compiler_mock = mocker.patch(
             "homcc.server.environment.Environment.invoke_compiler",
         )
@@ -199,19 +199,7 @@ class TestServerCompilation:
 
         # ensure that we call the compiler with an instruction to remap the debug symbols
         passed_debug_arguments: Arguments = invoke_compiler_mock.call_args_list[0].args[0]
-        assert f"-fdebug-prefix-map={instance_path}=" in passed_debug_arguments.args
-
-        no_debug_arguments = Arguments.from_args(
-            [
-                "gcc",
-                f"{mapped_cwd}/src/foo.cpp",
-            ]
-        )
-        environment.do_compilation(no_debug_arguments)
-
-        # ensure that the flag is not passed to the compiler when not compiling with debug symbols
-        passed_no_debug_arguments: Arguments = invoke_compiler_mock.call_args_list[1].args[0]
-        assert "-fdebug-prefix-map" not in str(passed_no_debug_arguments.args)
+        assert f"-ffile-prefix-map={instance_path}=" in passed_debug_arguments.args
 
     @pytest.mark.gplusplus
     def test_compiler_exists(self):


### PR DESCRIPTION
Prior we would only map debug symbols to a valid path on the client side using `-fdebug-prefix-map=OLD=NEW`.
We also have to map macros such as e.g. `__FILE__`. 
Luckily, there is the option to do just this by specifying `-ffile-prefix-map=OLD=NEW`, which translates macros and debug symbols.
This is available since GCC8 and Clang10. Therefore, for mappings to correctly work, using at minimum these versions is required now.

For more info, see https://reproducible-builds.org/docs/build-path/