### PR TITLE
CPL-7766: Activate Connecting and Preprocessing Phase

### DIFF
--- a/homcc/client/client.py
+++ b/homcc/client/client.py
@@ -238,10 +238,10 @@ class StateFile:
     class ClientPhase(int, Enum):
         """Client compilation phases equivalent to dcc_phase."""
 
-        _STARTUP = 0  # unused
+        STARTUP = 0
         _BLOCKED = auto()  # unused
-        _CONNECT = auto()  # unused
-        _CPP = auto()  # unused
+        CONNECT = auto()
+        CPP = auto()  # Preprocessing
         _SEND = auto()  # unused
         COMPILE = auto()
         _RECEIVE = auto()  # unused
@@ -315,9 +315,6 @@ class StateFile:
         # enum dcc_phase curr_phase: unassigned
         # struct dcc_task_state *next: DISTCC_NEXT_TASK_STATE
 
-        # we currently show the whole interaction as a COMPILE phase as we can not discern between sending and receiving
-        self.phase = self.ClientPhase.COMPILE
-
     def __bytes__(self) -> bytes:
         # fmt: off
         return struct.pack(
@@ -341,7 +338,7 @@ class StateFile:
         except FileExistsError:
             logger.debug("Could not create client state file '%s' as it already exists!", self.filepath.absolute())
 
-        self.filepath.write_bytes(bytes(self))
+        self.set_startup()
 
         return self
 
@@ -351,6 +348,22 @@ class StateFile:
         except FileNotFoundError:
             logger.debug("File '%s' was already deleted!", self.filepath.absolute())
 
+    def _set_phase(self, phase: ClientPhase):
+        self.phase = phase
+        self.filepath.write_bytes(bytes(self))
+
+    def set_startup(self):
+        self._set_phase(self.ClientPhase.STARTUP)
+
+    def set_connect(self):
+        self._set_phase(self.ClientPhase.CONNECT)
+
+    def set_preprocessing(self):
+        self._set_phase(self.ClientPhase.CPP)
+
+    def set_compile(self):
+        self._set_phase(self.ClientPhase.COMPILE)
+
 
 class TCPClient:
     """Wrapper class to exchange homcc protocol messages via TCP"""
@@ -359,7 +372,7 @@ class TCPClient:
     DEFAULT_BUFFER_SIZE_LIMIT: int = 65_536  # default buffer size limit of StreamReader is 64 KiB
     DEFAULT_OPEN_CONNECTION_TIMEOUT: float = 5
 
-    def __init__(self, host: Host):
+    def __init__(self, host: Host, state: StateFile):
         connection_type: ConnectionType = host.type
 
         if connection_type != ConnectionType.TCP:
@@ -372,6 +385,8 @@ class TCPClient:
         self._data: bytes = bytes()
         self._reader: asyncio.StreamReader
         self._writer: asyncio.StreamWriter
+
+        state.set_connect()
 
     async def __aenter__(self) -> TCPClient:
         """connect to specified server at host:port"""

--- a/homcc/client/compilation.py
+++ b/homcc/client/compilation.py
@@ -63,9 +63,9 @@ async def compile_remotely(arguments: Arguments, hosts: List[Host], config: Clie
         host.compression = host.compression or config.compression
 
         try:
-            with RemoteHostSemaphore(host), StateFile(arguments, host):
+            with RemoteHostSemaphore(host), StateFile(arguments, host) as state:
                 return await asyncio.wait_for(
-                    compile_remotely_at(arguments, host, schroot_profile, docker_container), timeout=timeout
+                    compile_remotely_at(arguments, host, schroot_profile, docker_container, state), timeout=timeout
                 )
 
         # remote semaphore could not be acquired
@@ -86,11 +86,12 @@ async def compile_remotely(arguments: Arguments, hosts: List[Host], config: Clie
 
 
 async def compile_remotely_at(
-    arguments: Arguments, host: Host, schroot_profile: Optional[str], docker_container: Optional[str]
+    arguments: Arguments, host: Host, schroot_profile: Optional[str], docker_container: Optional[str], state: StateFile
 ) -> int:
     """main function for the communication between client and a remote compilation host"""
 
-    async with TCPClient(host) as client:
+    async with TCPClient(host, state) as client:
+        state.set_preprocessing()
         dependency_dict: Dict[str, str] = calculate_dependency_dict(find_dependencies(arguments))
         remote_arguments: Arguments = arguments.copy().remove_local_args()
 
@@ -112,6 +113,7 @@ async def compile_remotely_at(
                 err,
             )
 
+        state.set_compile()
         await client.send_argument_message(
             arguments=remote_arguments,
             cwd=os.getcwd(),
@@ -180,7 +182,9 @@ async def compile_remotely_at(
 def compile_locally(arguments: Arguments, localhost: Host) -> int:
     """execute local compilation"""
 
-    with LocalHostSemaphore(localhost), StateFile(arguments, localhost):
+    with LocalHostSemaphore(localhost), StateFile(arguments, localhost) as state:
+        state.set_compile()
+
         try:
             # execute compile command, e.g.: "g++ foo.cpp -o foo"
             result: ArgumentsExecutionResult = arguments.execute(check=True, output=True)

--- a/tests/client/client_test.py
+++ b/tests/client/client_test.py
@@ -177,7 +177,7 @@ class TestLocalHostSemaphore:
     def test_release(self):
         localhost: Host = Host.localhost_with_limit(1)
         localhost.name = self.test_localhosts.__name__  # overwrite name to create dedicated test semaphore
-        host_id: str = localhost.id()
+        host_id: int = localhost.id()
 
         with pytest.raises(SystemExit):
             with LocalHostSemaphore(localhost, 2):


### PR DESCRIPTION
This PR enables multiple `ClientPhase`s for the `StateFile` (previously only `COMPILE` phase was active) required for better monitoring:
- `STARTUP`: initial default value, this will basically never be seen in the monitor as it's almost immediately being replaced
- `CONNECT`: only relevant for remote, is set by the `TCPClient`
- `CPP`: name is misleading (currently only kept to keep it close to `distcc`s naming, they also use [`"Preprocess"`](https://github.com/distcc/distcc/blob/b15870bdedfff33f68c17555a19fa58fd6cd1f2c/src/state.c#L117-L118) when it is user facing), only relevant for remote, is set before we do `dependency_finding`
- `COMPILE`: relevant for local and remote, was previous default, now set before `arguments` are executed (local) or set before sending the `ArgumentMessage` (this does not initiate the actual remote compilation as dependencies might still have to be sent beforehand)

New phases are already working in the `distcc` monitor as expected:
- red: `CONNECT`
- purple: `CPP`/`PREPROCESSING`
- green: `COMPILE`)
<details><summary>build startup:</summary>

![build startup](https://user-images.githubusercontent.com/95348275/200339200-bd9c8c4b-db8e-47fd-93b8-0bb0800c6bce.png)
</details>

<details><summary>build running:</summary>

![build running](https://user-images.githubusercontent.com/95348275/200339207-e2b53164-4df6-4b21-be3e-befccc9f9311.png)
</details>

> **Note**: after the `slot = 0` change phases of different compilations are aligned right after another of the top-most finished compilation so we get this stalactite formation