### PR TITLE
fix-error-client-message-on-unrecoverable-errors

### DIFF
--- a/homcc/client/compilation.py
+++ b/homcc/client/compilation.py
@@ -83,7 +83,7 @@ async def compile_remotely(arguments: Arguments, hosts: List[Host], config: Clie
         # arguments execution error during local pre-steps, unrecoverable failure
         except subprocess.CalledProcessError as error:
             check_recursive_call(arguments.compiler, error)
-            logger.error("%s", error)
+            logger.error(error.stderr)
             raise SystemExit(error.returncode) from error
 
         # compilation request timed out, local compilation fallback

--- a/homcc/common/arguments.py
+++ b/homcc/common/arguments.py
@@ -549,10 +549,10 @@ class Arguments:
     @staticmethod
     def _execute_args_sync(
         args: List[str],
-        check: bool = False,
-        cwd: Path = Path.cwd(),
-        output: bool = False,
-        timeout: Optional[float] = None,
+        check: bool,
+        cwd: Path,
+        output: bool,
+        timeout: Optional[float],
     ):
         result: subprocess.CompletedProcess = subprocess.run(
             args=args, check=check, cwd=cwd, encoding=ENCODING, capture_output=True, timeout=timeout
@@ -568,8 +568,8 @@ class Arguments:
     def _execute_async(
         args: List[str],
         event_socket_fd: int,
-        cwd: Path = Path.cwd(),
-        timeout: Optional[float] = None,
+        cwd: Path,
+        timeout: Optional[float],
     ) -> ArgumentsExecutionResult:
         start_time = time.time()
         with subprocess.Popen(args, cwd=cwd, stdout=subprocess.PIPE, stderr=subprocess.PIPE) as process:


### PR DESCRIPTION
This PR fixes the missing forwarding of unrecoverable client error reasons. Previously we only omitted that the compiler failed but not exactly why it failed.

Also removed unnecessary default parameters for the internals `Arguments._execute` methods.