### PR TITLE
fix-error-client-message-on-unrecoverable-errors-on-local-executions

### DIFF
--- a/homcc/client/compilation.py
+++ b/homcc/client/compilation.py
@@ -214,7 +214,7 @@ def execute_linking(arguments: Arguments, localhost: Host) -> int:
             result: ArgumentsExecutionResult = arguments.execute(check=True, output=True)
         except subprocess.CalledProcessError as error:
             check_recursive_call(arguments.compiler, error)
-            logger.error(error)
+            logger.error(error.stderr)
             raise SystemExit(error.returncode) from error
 
         return result.return_code
@@ -244,7 +244,7 @@ def scan_includes(arguments: Arguments) -> List[str]:
         dependencies: Set[str] = find_dependencies(arguments)
     except subprocess.CalledProcessError as error:
         check_recursive_call(arguments.compiler, error)
-        logger.error("%s", error)
+        logger.error(error.stderr)
         raise SystemExit(error.returncode) from error
 
     return [dependency for dependency in dependencies if not Arguments.is_source_file_arg(dependency)]

--- a/homcc/client/main.py
+++ b/homcc/client/main.py
@@ -54,7 +54,7 @@ def main():
 
     # exit on unrecoverable errors
     except RemoteCompilationError as error:
-        logger.error("%s", error.message)
+        logger.error(error.message)
         raise SystemExit(error.return_code) from error
 
     # compile locally on recoverable errors if local compilation is not disabled

--- a/homcc/client/parsing.py
+++ b/homcc/client/parsing.py
@@ -311,7 +311,7 @@ def setup_client(cli_args: List[str]) -> Tuple[ClientConfig, Arguments, Host, Li
         try:
             hosts_file, hosts_str = load_hosts()
         except NoHostsFoundError as error:
-            logger.error("%s", error)
+            logger.error(error.message)
             raise SystemExit(os.EX_NOINPUT) from error
 
         has_local: bool = False


### PR DESCRIPTION
This PR fixes the missing forwarding of unrecoverable client error reasons for local executions.

Additionally, also disabled `StateFile` creation for `linking_only` `arguments` since they are only shown with an irrelevant, empty `source_base_filename` string in the monitors.