### PR TITLE
Remove unused version variable from the VeraCode action and run VeraCode only on main

### DIFF
--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -7,10 +7,6 @@ on:
     paths-ignore:
       - README.md
       - .gitignore
-  pull_request:
-    types:
-      - opened
-      - synchronize
 
 jobs:
   linter:


### PR DESCRIPTION
The env variable was always empty but subject to an injection, so we remove it. 
The env variable itself was introduced in the first place because it was in the Confluence manual: https://confluence.celonis.com/pages/viewpage.action?pageId=183700255

Also we let VeraCode only run on `main`. 