### PR TITLE
fix: `None` Access `AttributeError` on `HostSemaphore` `__exit__`

### DIFF
--- a/homcc/client/client.py
+++ b/homcc/client/client.py
@@ -122,20 +122,19 @@ class HostSemaphore(ABC):
         pass
 
     def __exit__(self, *exc):
-        if self._semaphore is not None:
-            try:
-                logger.debug("Exiting semaphore '%s' with value '%i'", self._semaphore.id, self._semaphore.value)
+        try:
+            logger.debug("Exiting semaphore '%s' with value '%i'", self._semaphore.id, self._semaphore.value)
 
-                self._semaphore.release()  # releases the semaphore
+            self._semaphore.release()  # releases the semaphore
 
-                if self._semaphore.value == self._host_limit:
-                    # remove the semaphore from the system if no other process currently holds it
-                    self._semaphore.remove()
-            except sysv_ipc.ExistentialError:
-                pass
+            if self._semaphore.value == self._host_limit:
+                # remove the semaphore from the system if no other process currently holds it
+                self._semaphore.remove()
+        except (AttributeError, sysv_ipc.ExistentialError):
+            pass
 
-            # prevent double release while receiving signal during normal context manager exit
-            self._semaphore = None  # type: ignore
+        # prevent double release while receiving signal during normal context manager exit
+        self._semaphore = None  # type: ignore
 
 
 class RemoteHostSemaphore(HostSemaphore):


### PR DESCRIPTION
We currently have a related issue regarding `None` access during `HostSemaphore::__exit__` in `0.0.2` (e.g. when `Ctrl+C`ing a running build). However that exact issue was already fixed a while ago. Now there is only a very rare chance that it can occur. This PR fixes this issue by disregarding the resulting `AttributeError` explicitly.