### PR TITLE
Fix rare compatibility issue between 0.0.3 client and 0.0.4 server

### DIFF
--- a/homcc/server/environment.py
+++ b/homcc/server/environment.py
@@ -153,6 +153,12 @@ class Environment:
         """Does the compilation and returns the filled result message."""
         logger.info("Compiling...")
 
+        # TODO(o.layer): The next code line exists due to compatibility issues between 0.0.3 and 0.0.4,
+        # where the old client does not filter the -MD flag, but the newer server version
+        # expects the absence of the -MD flag. To fix this, the server temporarily removes local arguments.
+        # We can remove this after 0.0.4 is completely rolled out.
+        arguments = arguments.remove_local_args()
+
         mapped_cwd_path = Path(self.mapped_cwd)
 
         # create the mapped current working directory if it doesn't exist yet


### PR DESCRIPTION
- The 0.0.4 server keeps the `-o` argument so that fission works. But: `-o` does not work in conjunction with `-MD` flag.
- The 0.0.3 client does not remove the `-MD` argument, even though it is a local argument. (this is a bug in earlier client version, but which is just a problem for servers >= 0.0.4) 
- The 0.0.4 client correctly removes the `-MD`  argument

Therefore, this PR introduces removing of local arguments on the server side (even though it is the job of the client to do this so that the `ArgumentMessage` is kept small) temporarily, until every one upgraded to `0.0.4` clients.

For some reason this is not a problem for all `g++` compilations, I suspect different versions of `g++` handle this flag differently, for some versions of `g++`  leading to an error in conjunction with `-o` and for others not. E.g. when using our docker container, the problem does not occur, but when using the `jammy` schroot profile, the issue occurs.

**The question is also a bit if we really want to deploy it, as it only makes problems when using the schroot profile with the old client, using the new client + schroot profile works and it works in any case using the recommended way over the docker container.**