### PR TITLE
Fix broken pipe error (now really)

### DIFF
--- a/homcc/client/compilation.py
+++ b/homcc/client/compilation.py
@@ -146,28 +146,19 @@ async def compile_remotely_at(
 
         state.set_compile()
 
-        send_error: Optional[ConnectionError] = None
-        try:
-            await client.send_argument_message(
-                arguments=remote_arguments,
-                cwd=os.getcwd(),
-                dependency_dict=dependency_dict,
-                target=target,
-                schroot_profile=schroot_profile,
-                docker_container=docker_container,
-            )
-        except ConnectionError as error:
-            send_error = error
-
+        await client.send_argument_message(
+            arguments=remote_arguments,
+            cwd=os.getcwd(),
+            dependency_dict=dependency_dict,
+            target=target,
+            schroot_profile=schroot_profile,
+            docker_container=docker_container,
+        )
         host_response: Message = await client.receive()
         if isinstance(host_response, ConnectionRefusedMessage):
             raise HostRefusedConnectionError(
                 f"Host {client.host}:{client.port} refused the connection:\n{host_response.info}!"
             )
-
-        if send_error is not None:
-            # rethrow the ConnectionError, since at this point it can not be related to the server limit
-            raise send_error
 
         # invert dependency dictionary to access dependencies via hash
         dependency_dict = {file_hash: dependency for dependency, file_hash in dependency_dict.items()}


### PR DESCRIPTION
#74 did not fix the broken pipe issue completely.
The main issue is that the server sends a `ConnectionRefusedMessage` directly after the TCP connection has been established and then closes the connection. The client on the other hand first tries to send an `ArgumentMessage`, and then waits for a response from the server (either continuing with the protocol or ending it with an `ConnectionRefusedMessage`). The problem now is that when the server is very fast with closing the connection, and the client is slow with sending the `ArgumentMessage`, the connection is already closed when the client tries to send the `ArgumentMessage` and before it can try to read the server response, thus leading to a `BrokenPipe`. 

With this PR, we now catch this exception and provide proper output to the user. While this is sufficient for this version, at a later point in time we should make the protocol more clearer, so that this "bad" state does not have to be handled explicitly.