### PR TITLE
Upgrade setuptools

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,4 +15,4 @@ pytest-mock
 stdeb>=0.10.0
 
 watchdog~=2.3.0
-setuptools~=60.2.0
+setuptools


### PR DESCRIPTION
Remove `setuptools` version fixation so we automatically use the latest version. (should not be a problem)
GitHub showed a security issue for the old `setuptools` version:
![image](https://user-images.githubusercontent.com/10549770/226612961-d27d1958-fa6a-47e8-8591-6a3907195da6.png)
