### PR TITLE
fix: Do not fail if return code of compiler is != 0 for local compilations

### DIFF
--- a/homcc/client/compilation.py
+++ b/homcc/client/compilation.py
@@ -211,7 +211,7 @@ def execute_linking(arguments: Arguments, localhost: Host) -> int:
     """execute linking command, no StateFile necessary"""
 
     with LocalHostCompilationSemaphore(localhost):
-        result: ArgumentsExecutionResult = arguments.execute(check=True, output=True)
+        result: ArgumentsExecutionResult = arguments.execute(output=True)
 
         return result.return_code
 
@@ -223,7 +223,7 @@ def compile_locally(arguments: Arguments, localhost: Host) -> int:
         state.set_compile()
 
         # execute compile command, e.g.: "g++ -c foo.cpp -o foo"
-        result: ArgumentsExecutionResult = arguments.execute(check=True, output=True)
+        result: ArgumentsExecutionResult = arguments.execute(output=True)
 
         return result.return_code
 

--- a/tests/client/compilation_test.py
+++ b/tests/client/compilation_test.py
@@ -118,8 +118,4 @@ class TestCompilation:
 
         Path(output).unlink(missing_ok=True)
 
-        # intentionally execute an erroneous call
-        with pytest.raises(subprocess.CalledProcessError) as raised_exception:
-            compile_locally(Arguments.from_vargs(*args, "-OError"), Host.localhost_with_limit(1))
-
-        assert raised_exception != os.EX_OK
+        assert compile_locally(Arguments.from_vargs(*args, "-OError"), Host.localhost_with_limit(1)) != os.EX_OK


### PR DESCRIPTION
Previously, we would print a generic error message that the compiler process failed, but would not print the output of the compiler (e.g. when there is a compilation error).
By removing the `check` flag, we print stdout/stderr of the compiler and exit afterwards with the correct return code, so no need for `check`.