### PR TITLE
fix: Environment checks in sanboxed environments

### DIFF
--- a/homcc/client/compilation.py
+++ b/homcc/client/compilation.py
@@ -43,6 +43,7 @@ from homcc.common.messages import (
     Message,
 )
 from homcc.common.statefile import StateFile
+from homcc.server.shell_environment import HostShellEnvironment
 
 logger = logging.getLogger(__name__)
 
@@ -134,7 +135,7 @@ async def compile_remotely_at(
 
         target: Optional[str] = None
         try:
-            target = arguments.get_compiler_target_triple()
+            target = arguments.get_compiler_target_triple(shell_env=HostShellEnvironment())
         except TargetInferationError as err:
             logger.warning(
                 "Could not get target architecture. Omitting passing explicit target to remote compilation host. "
@@ -211,7 +212,7 @@ def execute_linking(arguments: Arguments, localhost: Host) -> int:
     """execute linking command, no StateFile necessary"""
 
     with LocalHostCompilationSemaphore(localhost):
-        result: ArgumentsExecutionResult = arguments.execute(check=True, output=True)
+        result: ArgumentsExecutionResult = arguments.execute(check=True, output=True, shell_env=HostShellEnvironment())
 
         return result.return_code
 
@@ -223,7 +224,7 @@ def compile_locally(arguments: Arguments, localhost: Host) -> int:
         state.set_compile()
 
         # execute compile command, e.g.: "g++ -c foo.cpp -o foo"
-        result: ArgumentsExecutionResult = arguments.execute(check=True, output=True)
+        result: ArgumentsExecutionResult = arguments.execute(check=True, output=True, shell_env=HostShellEnvironment())
 
         return result.return_code
 
@@ -246,7 +247,7 @@ def find_dependencies(arguments: Arguments) -> Set[str]:
 
     # execute preprocessor command, e.g.: "g++ foo.cpp -M"
     arguments, filename = arguments.dependency_finding()
-    result: ArgumentsExecutionResult = arguments.execute(check=True)
+    result: ArgumentsExecutionResult = arguments.execute(check=True, shell_env=HostShellEnvironment())
 
     # read from the dependency file if it was created as a side effect
     dependency_result: str = (
@@ -292,6 +293,6 @@ def link_object_files(arguments: Arguments, object_files: List[File]) -> int:
         arguments.add_arg(object_file.file_name)
 
     # execute linking command, e.g.: "g++ foo.o bar.o -ofoobar"
-    result: ArgumentsExecutionResult = arguments.execute(check=True, output=True)
+    result: ArgumentsExecutionResult = arguments.execute(check=True, output=True, shell_env=HostShellEnvironment())
 
     return result.return_code

--- a/homcc/server/docker.py
+++ b/homcc/server/docker.py
@@ -6,8 +6,10 @@
 import logging
 import shutil
 import subprocess
+from typing import List, Optional
 
 from homcc.common.constants import ENCODING
+from homcc.server.shell_environment import ShellEnvironment
 
 logger = logging.getLogger(__name__)
 
@@ -41,3 +43,22 @@ def is_valid_docker_container(docker_container: str) -> bool:
         return False
 
     return "true" in result.stdout
+
+
+class DockerShellEnvironment(ShellEnvironment):
+    """Docker shell environment. Commands are transformed to be executed inside a docker container."""
+
+    container: str
+
+    def __init__(self, container: str) -> None:
+        super().__init__()
+        self.container = container
+
+    def transform_command(self, args: List[str], cwd: Optional[str] = None) -> List[str]:
+        transformed_args: List[str] = ["docker", "exec"]
+
+        if cwd is not None:
+            transformed_args.extend(["--workdir", cwd])
+
+        transformed_args.append(self.container)
+        return transformed_args + args

--- a/homcc/server/environment.py
+++ b/homcc/server/environment.py
@@ -49,7 +49,7 @@ class Environment:
         sock_fd: int,
     ):
         def get_shell_env():
-            # TODO(o.layer): upgrade to match once we have use Python 3.10
+            # TODO(o.layer): upgrade to match once we use Python 3.10
             if docker_container is not None:
                 return DockerShellEnvironment(docker_container)
             elif schroot_profile is not None:

--- a/homcc/server/schroot.py
+++ b/homcc/server/schroot.py
@@ -7,9 +7,10 @@ import logging
 import re
 import shutil
 import subprocess
-from typing import List
+from typing import List, Optional
 
 from homcc.common.constants import ENCODING
+from homcc.server.shell_environment import ShellEnvironment
 
 logger = logging.getLogger(__name__)
 
@@ -41,3 +42,18 @@ def get_schroot_profiles() -> List[str]:
 def is_valid_schroot_profile(schroot_profile: str) -> bool:
     """Returns True if the given schroot profile exists."""
     return schroot_profile in get_schroot_profiles()
+
+
+class SchrootShellEnvironment(ShellEnvironment):
+    """Schroot shell environment. Commands are transformed to be executed inside a schroot profile."""
+
+    profile: str
+
+    def __init__(self, profile: str) -> None:
+        super().__init__()
+        self.profile = profile
+
+    def transform_command(self, args: List[str], cwd: Optional[str] = None) -> List[str]:
+        transformed_args: List[str] = ["schroot", "-c", self.profile, "--"]
+
+        return transformed_args + args

--- a/homcc/server/shell_environment.py
+++ b/homcc/server/shell_environment.py
@@ -1,0 +1,21 @@
+"""Shell environment module."""
+
+from abc import ABC, abstractmethod
+from typing import List, Optional
+
+
+class ShellEnvironment(ABC):
+    """Abstract class representing a shell environment. A shell environment defines
+    the shell in which commands are executed, e.g. inside a container or directly
+    on the host system."""
+
+    @abstractmethod
+    def transform_command(self, args: List[str], cwd: Optional[str] = None) -> List[str]:
+        pass
+
+
+class HostShellEnvironment(ShellEnvironment):
+    """Host shell environment. Commands are not transformed."""
+
+    def transform_command(self, args: List[str], cwd: Optional[str] = None) -> List[str]:
+        return args

--- a/tests/common/arguments_test.py
+++ b/tests/common/arguments_test.py
@@ -10,6 +10,7 @@ import pytest
 
 from homcc.common.arguments import Arguments, Clang, Compiler, Gcc
 from homcc.common.errors import UnsupportedCompilerError
+from homcc.server.shell_environment import HostShellEnvironment
 
 
 class TestArguments:
@@ -267,13 +268,15 @@ class TestGcc:
     @pytest.mark.gplusplus
     def test_supports_target(self):
         gcc = Gcc("g++")
-        assert gcc.supports_target("x86_64-linux-gnu")
-        assert not gcc.supports_target("other_arch-linux-gnu")
+        assert gcc.supports_target("x86_64-linux-gnu", shell_env=HostShellEnvironment())
+        assert not gcc.supports_target("other_arch-linux-gnu", shell_env=HostShellEnvironment())
 
     @pytest.mark.gplusplus
     def test_get_target_triple(self):
         gcc = Gcc("g++")
-        assert gcc.get_target_triple()  # check no exception is thrown and we got a non-empty string
+
+        # check no exception is thrown and we got a non-empty string
+        assert gcc.get_target_triple(shell_env=HostShellEnvironment())
 
     def test_add_target_to_arguments(self):
         gcc = Gcc("g++")
@@ -293,7 +296,8 @@ class TestClang:
     @pytest.mark.clangplusplus
     def test_get_target_triple(self):
         clang = Clang("clang++")
-        assert clang.get_target_triple()  # check no exception is thrown and we got a non-empty string
+        # check no exception is thrown and we got a non-empty string
+        assert clang.get_target_triple(shell_env=HostShellEnvironment())
 
     def test_add_target_to_arguments(self):
         clang = Clang("clang++")

--- a/tests/server/environment_test.py
+++ b/tests/server/environment_test.py
@@ -14,6 +14,7 @@ from homcc.common.arguments import Arguments
 from homcc.common.compression import NoCompression
 from homcc.server.cache import Cache
 from homcc.server.environment import ArgumentsExecutionResult, Environment
+from homcc.server.shell_environment import HostShellEnvironment
 
 
 def create_mock_environment(instance_folder: str, mapped_cwd: str) -> Environment:
@@ -23,7 +24,7 @@ def create_mock_environment(instance_folder: str, mapped_cwd: str) -> Environmen
 
     environment.instance_folder = instance_folder
     environment.mapped_cwd = mapped_cwd
-    environment.schroot_profile = None
+    environment.shell_env = HostShellEnvironment()
     environment.compression = NoCompression()
 
     return environment
@@ -210,8 +211,10 @@ class TestServerCompilation:
 
     @pytest.mark.gplusplus
     def test_compiler_exists(self):
-        assert Environment.compiler_exists(Arguments.from_vargs("g++", "foo"))
-        assert not Environment.compiler_exists(Arguments.from_vargs("clang-HOMCC_TEST_COMPILER_EXISTS", "foo"))
+        environment = create_mock_environment("instance-folder", "instance-folder/some-folder")
+
+        assert environment.compiler_exists(Arguments.from_vargs("g++", "foo"))
+        assert not environment.compiler_exists(Arguments.from_vargs("clang-HOMCC_TEST_COMPILER_EXISTS", "foo"))
 
     def test_map_source_file_to_object_file(self):
         instance_path: str = "/tmp/instance/"

--- a/tests/server/server_test.py
+++ b/tests/server/server_test.py
@@ -31,41 +31,31 @@ class TestServer:
         self.request_handler = TCPRequestHandler.__new__(TCPRequestHandler)
         self.request_handler.server = MagicMock()
         self.request_handler.request = MagicMock()
+        self.request_handler.environment = MagicMock()
 
-    def test_check_compiler_arguments(self, mocker: MockerFixture):
-        mocker.patch(
-            "homcc.server.environment.Environment.compiler_exists",
-            return_value=False,
-        )
+    def test_check_compiler_arguments(self):
+        self.request_handler.environment.compiler_exists.return_value = False  # type: ignore
 
         arguments = MagicMock()
         with patch.object(self.request_handler, "close_connection") as mocked_close_connection:
             assert not self.request_handler.check_compiler_arguments(arguments)
             mocked_close_connection.assert_called_once()
 
-        mocker.patch(
-            "homcc.server.environment.Environment.compiler_exists",
-            return_value=True,
-        )
+        self.request_handler.environment.compiler_exists.return_value = True  # type: ignore
         with patch.object(self.request_handler, "close_connection") as mocked_close_connection:
             assert self.request_handler.check_compiler_arguments(arguments)
             mocked_close_connection.assert_not_called()
 
-    def test_check_target_argument(self, mocker: MockerFixture):
-        mocker.patch(
-            "homcc.server.environment.Environment.compiler_supports_target",
-            return_value=False,
-        )
+    def test_check_target_argument(self):
+        self.request_handler.environment.compiler_supports_target.return_value = False  # type: ignore
 
         arguments = MagicMock()
         with patch.object(self.request_handler, "close_connection") as mocked_close_connection:
             assert not self.request_handler.check_target_argument(arguments, "some_target")
             mocked_close_connection.assert_called_once()
 
-        mocker.patch(
-            "homcc.server.environment.Environment.compiler_supports_target",
-            return_value=True,
-        )
+        self.request_handler.environment.compiler_supports_target.return_value = True  # type: ignore
+
         with patch.object(self.request_handler, "close_connection") as mocked_close_connection:
             assert self.request_handler.check_target_argument(arguments, "some_target")
             mocked_close_connection.assert_not_called()
@@ -159,7 +149,7 @@ class TestServerReceive:
         # justification: needed for monkey patching
         # monkey patch the server's handler, so that we can compare
         # messages sent by the client with messages that the server deserialized
-        TCPRequestHandler._handle_message = self.patched_handle_message
+        TCPRequestHandler._handle_message = self.patched_handle_message  # type: ignore
 
         config: ServerConfig = ServerConfig(files=[], address="0.0.0.0", port=unused_tcp_port, limit=1)
 


### PR DESCRIPTION
This PR solves an issue that has been there for quite a while now: previously, we would not check if a compiler exists in a sandboxed environment (and e.g. also, if it supports the selected target), leading to weird errors. This made especially setting up cross-compiling harder.
I refactored this now, so that we always know in which context (= shell environment) we are in, by introducing an abstract `ShellEnvironment` class. Inheriting classes must implement `transform_command`, which transforms a command so that it is executed inside a sandbox. When executing a command, we must now always pass the context in which we are in and in which the command should be executed. 
This makes the code cleaner, and allows us to check all environment related things also in the sandbox.