### PR TITLE
Fix actions

### DIFF
--- a/.github/workflows/build-branch.yml
+++ b/.github/workflows/build-branch.yml
@@ -5,7 +5,7 @@ on:
     branches-ignore:
       - main
   pull_request:
-      types: [opened, reopened]
+      types: [opened, synchronize, reopened]
 jobs:
   linter:
     runs-on: ubuntu-22.04

--- a/.github/workflows/build-branch.yml
+++ b/.github/workflows/build-branch.yml
@@ -1,10 +1,11 @@
-name: Build PR Branch
+name: Build Branch/PR
 
 on:
   push:
     branches-ignore:
       - main
-
+  pull_request:
+      types: [opened, reopened]
 jobs:
   linter:
     runs-on: ubuntu-22.04

--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -1,4 +1,4 @@
-name: Build Main and PR Branch
+name: Build Main
 
 on:
   push:
@@ -104,49 +104,3 @@ jobs:
           name: homcc_debian_packages
           path: target/
           if-no-files-found: error
-  vera-code:
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-      - name: Setup python
-        uses: actions/setup-python@v4
-        with:
-          python-version: '3.9'
-          cache: 'pip'
-      - name: Install dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install liblzo2-dev
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
-      - name: Run Veracode SCA Scan
-        env:
-          SRCCLR_API_TOKEN: ${{ secrets.SRCCLR_API_TOKEN }}
-        run: curl -sSL https://download.sourceclear.com/ci.sh | sh -s -- scan --loud --allow-dirty
-      - name: Zip repository
-        run: zip -r homcc.zip .
-      - name: Run Veracode SAST Scan
-        uses: veracode/veracode-uploadandscan-action@master
-        id: upload_and_scan
-        with:
-          # this is the reason why the application name in veracode; it needs to match the name of github repository
-          appname: '${{ github.repository }}'
-
-          # this assigns an ID to the scan on veracode platform
-          version: '${{ github.run_id }}'
-
-          filepath: 'homcc.zip'
-
-          # these are set globally
-          vid: '${{ secrets.VERACODE_API_ID }}'
-          vkey: '${{ secrets.VERACODE_API_SECRET }}'
-
-          # set to 'true' for develop branch, it will not affect project score but will give policy results
-          # set to 'false' for master branch
-          createsandbox: false
-
-          # minutes to wait until the end of the scan
-          scantimeout: 30
-      - name: Remove VeraCode artifact
-        run: rm homcc.zip


### PR DESCRIPTION
- Remove VeraCode action as the secrets are not available any more as we turned public
- Trigger build jobs on PR open, so that we can approve CI runs of 3rd party contributors when they create an PR