### PR TITLE
feat: LRU cache for dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,8 @@ Additionally, `HOMCC` provides sandboxed compiler execution for remote compilati
     HOMCCD_ADDRESS
     HOMCCD_LOG_LEVEL
     HOMCCD_VERBOSE
+    HOMCC_MAX_DEPENDENCY_CACHE_SIZE
+
     </pre></sub></td>
     <td><sub><pre lang="ini">
     [homcc]
@@ -188,6 +190,7 @@ Additionally, `HOMCC` provides sandboxed compiler execution for remote compilati
     address=0.0.0.0
     log_level=DEBUG
     verbose=True
+    max_dependency_cache_size=10G
     </pre></sub></td>
     <td><sub><pre>
     # Client configuration
@@ -207,6 +210,7 @@ Additionally, `HOMCC` provides sandboxed compiler execution for remote compilati
     IP address to listen on
     Detail level for log messages: {DEBUG, INFO, WARNING, ERROR, CRITICAL}
     Enable verbosity mode which implies detailed and colored logging
+    Maximum size of the dependency cache. You must specify either 'M' (Mebibyte) or 'G' (Gibibyte) as suffix.
     </pre></sub></td>
     </tr>
   </table>
@@ -214,7 +218,6 @@ Additionally, `HOMCC` provides sandboxed compiler execution for remote compilati
 ## Deployment hints
 Things to keep in mind when deploying `homccd`:
 - `homcc` currently does not support any transport encryption such as TLS, so source files would get transmitted over the internet in plain text if not using a VPN.
-- `homccd` currently does not support cache eviction. The dependency cache is therefore growing until there is no space any more. We recommend to restart the `homccd` service every 24 hours (e.g. using a cronjob) so that the cache gets cleared regularly.
 - `homccd` does not limit simultaneous connections of a single client. A malicious client could therefore block the service by always opening up connections until no server slots are available any more.
 - `homccd` does not limit access to docker containers or chroot environments. A client can choose any docker container or chroot environment available on the server to execute the compilation in. 
 

--- a/homcc/server/cache.py
+++ b/homcc/server/cache.py
@@ -57,18 +57,17 @@ class Cache:
         """
         oldest_hash, oldest_path_str = self.cache.popitem(last=False)
         oldest_path = Path(oldest_path_str)
-        oldest_size = oldest_path.stat().st_size
 
         try:
+            self.current_size_bytes -= oldest_path.stat().st_size
             oldest_path.unlink(missing_ok=False)
         except FileNotFoundError:
             logger.error(
-                "Tried to evict cache entry with hash '%s', but corresponding cache file at '%s' did not exist.",
+                """Tried to evict cache entry with hash '%s', but corresponding cache file at '%s' did not exist. 
+                This may lead to an invalid cache size calculation.""",
                 oldest_hash,
                 oldest_path,
             )
-
-        self.current_size_bytes -= oldest_size
 
     @staticmethod
     def _create_cache_folder(root_temp_folder: Path) -> Path:

--- a/homcc/server/cache.py
+++ b/homcc/server/cache.py
@@ -3,32 +3,77 @@
 #   https://github.com/celonis/homcc/blob/main/LICENSE
 
 """Caching module of the homcc server."""
+from collections import OrderedDict
 import logging
 from pathlib import Path
 from threading import Lock
-from typing import Dict
 
 logger = logging.getLogger(__name__)
+
+
+def mib_to_bytes(mb: int) -> int:
+    return mb * 1024**2
 
 
 class Cache:
     """Represents the homcc server cache that is used to cache dependencies."""
 
-    cache: Dict[str, str]
+    cache: OrderedDict[str, str]
     """'Hash' -> 'File path' on server map for holding paths to cached files"""
     cache_mutex: Lock
     """Mutex for locking the cache."""
     cache_folder: Path
     """Path to the cache on the file system."""
+    max_size_bytes: int
+    """Maximum size in bytes of the cache."""
+    current_size: int
+    """Current size in bytes"""
 
-    def __init__(self, root_folder: Path):
+    def __init__(self, root_folder: Path, max_size_bytes: int):
+        if max_size_bytes <= 0:
+            raise RuntimeError("Maximum size of cache must be strictly positive.")
+
         self.cache_folder = self._create_cache_folder(root_folder)
-        self.cache: Dict[str, str] = {}
+        self.cache: OrderedDict[str, str] = OrderedDict()
         self.cache_mutex: Lock = Lock()
+        self.max_size_bytes = max_size_bytes
+        self.current_size = 0
 
-    def __contains__(self, key):
+    def _get_cache_file_path(self, hash: str) -> Path:
+        return self.cache_folder / hash
+
+    def __contains__(self, key: str):
         with self.cache_mutex:
-            return key in self.cache
+            contained: bool = key in self.cache
+            if contained:
+                self.cache.move_to_end(key)
+
+            return contained
+
+    def __len__(self) -> int:
+        with self.cache_mutex:
+            return len(self.cache)
+
+    def _evict_oldest(self):
+        """
+        Evicts the oldest entry from the cache.
+        Note: The caller of this method has to ensure that the cache is locked.
+        """
+        oldest_hash = next(iter(self.cache))
+        oldest_path = self._get_cache_file_path(oldest_hash)
+        oldest_size = oldest_path.stat().st_size
+
+        try:
+            Path.unlink(oldest_path, missing_ok=False)
+        except FileNotFoundError:
+            logger.error(
+                "Tried to evict cache entry with hash '%s', but corresponding cache file at '%s' did not exist.",
+                oldest_hash,
+                oldest_path,
+            )
+
+        self.current_size -= oldest_size
+        del self.cache[oldest_hash]
 
     @staticmethod
     def _create_cache_folder(root_temp_folder: Path) -> Path:
@@ -39,15 +84,29 @@ class Cache:
         logger.info("Created cache folder in '%s'.", cache_folder.absolute())
         return cache_folder
 
-    def get(self, hash_value: str) -> str:
+    def get(self, hash: str) -> str:
         """Gets an entry (path) from the cache given a hash."""
         with self.cache_mutex:
-            return self.cache[hash_value]
+            self.cache.move_to_end(hash)
+            return self.cache[hash]
 
-    def put(self, hash_value: str, content: bytearray):
+    def put(self, hash: str, content: bytearray):
         """Stores a dependency in the cache."""
-        cached_file_path = self.cache_folder / hash_value
-        Path.write_bytes(cached_file_path, content)
+        if len(content) > self.max_size_bytes:
+            logger.error(
+                """File with hash '%s' can not be added to cache as it is larger than the maximum cache size.
+                (size in bytes: %i, max. cache size in bytes: %i)""",
+                hash,
+                len(content),
+                self.max_size_bytes,
+            )
+            raise RuntimeError("Cache size insufficient")
 
+        cached_file_path = self._get_cache_file_path(hash)
         with self.cache_mutex:
-            self.cache[hash_value] = str(cached_file_path)
+            while self.current_size + len(content) > self.max_size_bytes:
+                self._evict_oldest()
+
+            Path.write_bytes(cached_file_path, content)
+            self.current_size += len(content)
+            self.cache[hash] = str(cached_file_path)

--- a/homcc/server/cache.py
+++ b/homcc/server/cache.py
@@ -55,12 +55,12 @@ class Cache:
         Evicts the oldest entry from the cache.
         Note: The caller of this method has to ensure that the cache is locked.
         """
-        oldest_hash, _ = self.cache.popitem(last=False)
-        oldest_path = self._get_cache_file_path(oldest_hash)
+        oldest_hash, oldest_path_str = self.cache.popitem(last=False)
+        oldest_path = Path(oldest_path_str)
         oldest_size = oldest_path.stat().st_size
 
         try:
-            Path.unlink(oldest_path, missing_ok=False)
+            oldest_path.unlink(missing_ok=False)
         except FileNotFoundError:
             logger.error(
                 "Tried to evict cache entry with hash '%s', but corresponding cache file at '%s' did not exist.",

--- a/homcc/server/cache.py
+++ b/homcc/server/cache.py
@@ -3,8 +3,8 @@
 #   https://github.com/celonis/homcc/blob/main/LICENSE
 
 """Caching module of the homcc server."""
-from collections import OrderedDict
 import logging
+from collections import OrderedDict
 from pathlib import Path
 from threading import Lock
 

--- a/homcc/server/main.py
+++ b/homcc/server/main.py
@@ -67,6 +67,9 @@ def main():
         level=LogLevel.INFO,
     )
 
+    # TODO(o.layer): The argument parsing code should below be moved to/abstracted in parsing.py,
+    # similar to how it is done for the client
+
     # LOG_LEVEL and VERBOSITY
     log_level: Optional[str] = homccd_args_dict["log_level"]
 
@@ -99,6 +102,10 @@ def main():
     # ADDRESS
     if (address := homccd_args_dict["listen"]) is not None:
         homccd_config.address = address
+
+    # MAX_DEPENDENCY_CACHE_SIZE_BYTES
+    if (max_dependency_cache_size_bytes := homccd_args_dict["max_dependency_cache_size_bytes"]) is not None:
+        homccd_config.max_dependency_cache_size_bytes = max_dependency_cache_size_bytes
 
     # provide additional DEBUG information
     logger.debug(

--- a/homcc/server/main.py
+++ b/homcc/server/main.py
@@ -45,6 +45,7 @@ from homcc.server.parsing import (  # pylint: disable=wrong-import-position
     ServerConfig,
     parse_cli_args,
     parse_config,
+    size_string_to_bytes,
 )
 from homcc.server.server import (  # pylint: disable=wrong-import-position
     start_server,
@@ -103,9 +104,9 @@ def main():
     if (address := homccd_args_dict["listen"]) is not None:
         homccd_config.address = address
 
-    # MAX_DEPENDENCY_CACHE_SIZE_BYTES
-    if (max_dependency_cache_size_bytes := homccd_args_dict["max_dependency_cache_size_bytes"]) is not None:
-        homccd_config.max_dependency_cache_size_bytes = max_dependency_cache_size_bytes
+    # MAX_DEPENDENCY_CACHE_SIZE
+    if (max_dependency_cache_size := homccd_args_dict["max_dependency_cache_size"]) is not None:
+        homccd_config.max_dependency_cache_size_bytes = size_string_to_bytes(max_dependency_cache_size)
 
     # provide additional DEBUG information
     logger.debug(

--- a/homcc/server/server.py
+++ b/homcc/server/server.py
@@ -77,7 +77,7 @@ class TCPServer(socketserver.ThreadingMixIn, socketserver.TCPServer):
         self.current_amount_connections: int = 0  # indicates the amount of clients that are currently connected
         self.current_amount_connections_mutex: Lock = Lock()
 
-        self.cache = Cache(Path(self.root_temp_folder.name))
+        self.cache = Cache(root_folder=Path(self.root_temp_folder.name), max_entries=1000)  # TODO
 
     @staticmethod
     def send_message(request, message: Message):

--- a/homcc/server/server.py
+++ b/homcc/server/server.py
@@ -41,6 +41,7 @@ from homcc.server.environment import (
 from homcc.server.parsing import (
     DEFAULT_ADDRESS,
     DEFAULT_LIMIT,
+    DEFAULT_MAX_CACHE_SIZE_BYTES,
     DEFAULT_PORT,
     ServerConfig,
 )
@@ -56,7 +57,9 @@ logger = logging.getLogger(__name__)
 class TCPServer(socketserver.ThreadingMixIn, socketserver.TCPServer):
     """TCP Server instance, holding data relevant across compilations."""
 
-    def __init__(self, address: Optional[str], port: Optional[int], limit: Optional[int]):
+    def __init__(
+        self, address: Optional[str], port: Optional[int], limit: Optional[int], max_cache_size_bytes: Optional[int]
+    ):
         address = address or DEFAULT_ADDRESS
         port = port or DEFAULT_PORT
 
@@ -77,7 +80,8 @@ class TCPServer(socketserver.ThreadingMixIn, socketserver.TCPServer):
         self.current_amount_connections: int = 0  # indicates the amount of clients that are currently connected
         self.current_amount_connections_mutex: Lock = Lock()
 
-        self.cache = Cache(root_folder=Path(self.root_temp_folder.name), max_entries=1000)  # TODO
+        max_cache_size_bytes = max_cache_size_bytes or DEFAULT_MAX_CACHE_SIZE_BYTES
+        self.cache = Cache(root_folder=Path(self.root_temp_folder.name), max_size_bytes=max_cache_size_bytes)
 
     @staticmethod
     def send_message(request, message: Message):
@@ -518,7 +522,7 @@ class TCPRequestHandler(socketserver.BaseRequestHandler):
 
 def start_server(config: ServerConfig) -> Tuple[TCPServer, threading.Thread]:
     try:
-        server: TCPServer = TCPServer(config.address, config.port, config.limit)
+        server: TCPServer = TCPServer(config.address, config.port, config.limit, config.max_dependency_cache_size_bytes)
     except OSError as err:
         logger.error("Could not start TCP server: %s", err)
         raise ServerInitializationError from err

--- a/tests/server/cache_test.py
+++ b/tests/server/cache_test.py
@@ -42,83 +42,75 @@ class TestCache:
 
             assert "other_hash" not in cache
 
+    @staticmethod
+    def assert_hash_in_cache(cache: Cache, hash_value: str):
+        assert hash_value in cache
+        assert (cache.cache_folder / hash_value).exists()
+
+    @staticmethod
+    def assert_hash_not_in_cache(cache: Cache, hash_value: str):
+        assert hash_value not in cache
+        assert not (cache.cache_folder / hash_value).exists()
+
     def test_eviction_size_limit(self):
         with TemporaryDirectory() as tmp_dir:
-            root_dir = Path(tmp_dir)
-            cache = Cache(root_dir, max_size_bytes=10)
-            cache_dir = root_dir / "cache"
+            cache = Cache(Path(tmp_dir), max_size_bytes=10)
 
             cache.put("hash1", bytearray([0x1, 0x2, 0x3, 0x9]))
             cache.put("hash2", bytearray([0x1, 0x2, 0x3, 0xA]))
             cache.put("hash3", bytearray([0xFF, 0xFF]))
             assert len(cache) == 3
-            assert (cache_dir / "hash1").exists()
-            assert (cache_dir / "hash2").exists()
-            assert (cache_dir / "hash3").exists()
+            self.assert_hash_in_cache(cache, "hash1")
+            self.assert_hash_in_cache(cache, "hash2")
+            self.assert_hash_in_cache(cache, "hash3")
 
             cache.put("hash4", bytearray([0x1]))
             assert len(cache) == 3
-            assert "hash2" in cache
-            assert "hash3" in cache
-            assert "hash4" in cache
-            assert not (cache_dir / "hash1").exists()
-            assert (cache_dir / "hash2").exists()
-            assert (cache_dir / "hash3").exists()
-            assert (cache_dir / "hash4").exists()
+            self.assert_hash_not_in_cache(cache, "hash1")
+            self.assert_hash_in_cache(cache, "hash2")
+            self.assert_hash_in_cache(cache, "hash3")
+            self.assert_hash_in_cache(cache, "hash4")
 
             cache.put("hash5", bytearray([0x1]))
             assert len(cache) == 4
-            assert "hash2" in cache
-            assert "hash3" in cache
-            assert "hash4" in cache
-            assert "hash5" in cache
-            assert (cache_dir / "hash2").exists()
-            assert (cache_dir / "hash3").exists()
-            assert (cache_dir / "hash4").exists()
-            assert (cache_dir / "hash5").exists()
+            self.assert_hash_in_cache(cache, "hash2")
+            self.assert_hash_in_cache(cache, "hash3")
+            self.assert_hash_in_cache(cache, "hash4")
+            self.assert_hash_in_cache(cache, "hash5")
 
             cache.put("hash6", bytearray([0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9]))
             assert len(cache) == 2
-            assert not (cache_dir / "hash2").exists()
-            assert not (cache_dir / "hash3").exists()
-            assert not (cache_dir / "hash4").exists()
-            assert "hash5" in cache
-            assert "hash6" in cache
+            self.assert_hash_not_in_cache(cache, "hash2")
+            self.assert_hash_not_in_cache(cache, "hash3")
+            self.assert_hash_not_in_cache(cache, "hash4")
+            self.assert_hash_in_cache(cache, "hash5")
+            self.assert_hash_in_cache(cache, "hash6")
 
     def test_eviction_order_lru(self):
         with TemporaryDirectory() as tmp_dir:
-            root_dir = Path(tmp_dir)
-            cache = Cache(root_dir, max_size_bytes=10)
-            cache_dir = root_dir / "cache"
+            cache = Cache(Path(tmp_dir), max_size_bytes=10)
 
             cache.put("hash1", bytearray([0x1, 0x2, 0x3, 0x9]))
             cache.put("hash2", bytearray([0x1, 0x2, 0x3, 0xA]))
             cache.put("hash3", bytearray([0xFF, 0xFF]))
             assert len(cache) == 3
-            assert (cache_dir / "hash1").exists()
-            assert (cache_dir / "hash2").exists()
-            assert (cache_dir / "hash3").exists()
+            self.assert_hash_in_cache(cache, "hash1")
+            self.assert_hash_in_cache(cache, "hash2")
+            self.assert_hash_in_cache(cache, "hash3")
 
             cache.get("hash1")  # make "hash1" the latest used element
             cache.put("hash4", bytearray([0xFF, 0xFF, 0x0, 0x0]))
             assert len(cache) == 3
-            assert "hash2" not in cache
-            assert "hash1" in cache
-            assert "hash3" in cache
-            assert "hash4" in cache
-            # TODO: method for asserts combining IO exists and cache exists to reduce boilerplate
-            assert not (cache_dir / "hash2").exists()
-            assert (cache_dir / "hash1").exists()
-            assert (cache_dir / "hash3").exists()
-            assert (cache_dir / "hash4").exists()
+            self.assert_hash_not_in_cache(cache, "hash2")
+            self.assert_hash_in_cache(cache, "hash1")
+            self.assert_hash_in_cache(cache, "hash3")
+            self.assert_hash_in_cache(cache, "hash4")
 
             assert "hash3" in cache  # make "hash3" the latest used element
             cache.put("hash5", bytearray([0xFF, 0xFF, 0x0, 0x0, 0xFF, 0xFF, 0x0, 0x0]))
             assert len(cache) == 2
-            assert "hash3" in cache
-            assert "hash5" in cache
-            assert not (cache_dir / "hash1").exists()
-            assert not (cache_dir / "hash2").exists()
-            assert (cache_dir / "hash3").exists()
-            assert not (cache_dir / "hash4").exists()
-            assert (cache_dir / "hash5").exists()
+            self.assert_hash_in_cache(cache, "hash3")
+            self.assert_hash_in_cache(cache, "hash5")
+            self.assert_hash_not_in_cache(cache, "hash1")
+            self.assert_hash_not_in_cache(cache, "hash2")
+            self.assert_hash_not_in_cache(cache, "hash4")

--- a/tests/server/cache_test.py
+++ b/tests/server/cache_test.py
@@ -13,30 +13,112 @@ from homcc.server.cache import Cache
 class TestCache:
     """Tests the server cache."""
 
-    def test(self):
+    def test_simple(self):
         with TemporaryDirectory() as tmp_dir:
-            cache_dir = Path(tmp_dir)
-            cache = Cache(cache_dir)
+            root_dir = Path(tmp_dir)
+            cache = Cache(root_dir, 1000)
+            cache_dir = root_dir / "cache"
 
             file1 = bytearray([0x1, 0x2, 0x3, 0x9])
             cache.put("hash1", file1)
 
-            assert cache.get("hash1") == str(cache_dir / "cache" / "hash1")
+            assert cache.get("hash1") == str(cache_dir / "hash1")
             assert "hash1" in cache
             assert Path.read_bytes(Path(cache.get("hash1"))) == file1
 
             file2 = bytearray([0x3, 0x6, 0x3, 0x9])
             cache.put("hash2", file2)
 
-            assert cache.get("hash2") == str(cache_dir / "cache" / "hash2")
+            assert cache.get("hash2") == str(cache_dir / "hash2")
             assert "hash2" in cache
             assert Path.read_bytes(Path(cache.get("hash2"))) == file2
 
             file3 = bytearray([0x4, 0x2])
             cache.put("hash3", file3)
 
-            assert cache.get("hash3") == str(cache_dir / "cache" / "hash3")
+            assert cache.get("hash3") == str(cache_dir / "hash3")
             assert "hash3" in cache
             assert Path.read_bytes(Path(cache.get("hash3"))) == file3
 
             assert "other_hash" not in cache
+
+    def test_eviction_size_limit(self):
+        with TemporaryDirectory() as tmp_dir:
+            root_dir = Path(tmp_dir)
+            cache = Cache(root_dir, max_size_bytes=10)
+            cache_dir = root_dir / "cache"
+
+            cache.put("hash1", bytearray([0x1, 0x2, 0x3, 0x9]))
+            cache.put("hash2", bytearray([0x1, 0x2, 0x3, 0xA]))
+            cache.put("hash3", bytearray([0xFF, 0xFF]))
+            assert len(cache) == 3
+            assert (cache_dir / "hash1").exists()
+            assert (cache_dir / "hash2").exists()
+            assert (cache_dir / "hash3").exists()
+
+            cache.put("hash4", bytearray([0x1]))
+            assert len(cache) == 3
+            assert "hash2" in cache
+            assert "hash3" in cache
+            assert "hash4" in cache
+            assert not (cache_dir / "hash1").exists()
+            assert (cache_dir / "hash2").exists()
+            assert (cache_dir / "hash3").exists()
+            assert (cache_dir / "hash4").exists()
+
+            cache.put("hash5", bytearray([0x1]))
+            assert len(cache) == 4
+            assert "hash2" in cache
+            assert "hash3" in cache
+            assert "hash4" in cache
+            assert "hash5" in cache
+            assert (cache_dir / "hash2").exists()
+            assert (cache_dir / "hash3").exists()
+            assert (cache_dir / "hash4").exists()
+            assert (cache_dir / "hash5").exists()
+
+            cache.put("hash6", bytearray([0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9]))
+            assert len(cache) == 2
+            assert not (cache_dir / "hash2").exists()
+            assert not (cache_dir / "hash3").exists()
+            assert not (cache_dir / "hash4").exists()
+            assert "hash5" in cache
+            assert "hash6" in cache
+
+    def test_eviction_order_lru(self):
+        with TemporaryDirectory() as tmp_dir:
+            root_dir = Path(tmp_dir)
+            cache = Cache(root_dir, max_size_bytes=10)
+            cache_dir = root_dir / "cache"
+
+            cache.put("hash1", bytearray([0x1, 0x2, 0x3, 0x9]))
+            cache.put("hash2", bytearray([0x1, 0x2, 0x3, 0xA]))
+            cache.put("hash3", bytearray([0xFF, 0xFF]))
+            assert len(cache) == 3
+            assert (cache_dir / "hash1").exists()
+            assert (cache_dir / "hash2").exists()
+            assert (cache_dir / "hash3").exists()
+
+            cache.get("hash1")  # make "hash1" the latest used element
+            cache.put("hash4", bytearray([0xFF, 0xFF, 0x0, 0x0]))
+            assert len(cache) == 3
+            assert "hash2" not in cache
+            assert "hash1" in cache
+            assert "hash3" in cache
+            assert "hash4" in cache
+            # TODO: method for asserts combining IO exists and cache exists to reduce boilerplate
+            assert not (cache_dir / "hash2").exists()
+            assert (cache_dir / "hash1").exists()
+            assert (cache_dir / "hash3").exists()
+            assert (cache_dir / "hash4").exists()
+
+            assert "hash3" in cache  # make "hash3" the latest used element
+            cache.put("hash5", bytearray([0xFF, 0xFF, 0x0, 0x0, 0xFF, 0xFF, 0x0, 0x0]))
+            assert len(cache) == 2
+            assert "hash3" in cache
+            assert "hash5" in cache
+            assert not (cache_dir / "hash1").exists()
+            assert not (cache_dir / "hash2").exists()
+            assert (cache_dir / "hash3").exists()
+            assert not (cache_dir / "hash4").exists()
+            assert (cache_dir / "hash5").exists()

--- a/tests/server/cache_test.py
+++ b/tests/server/cache_test.py
@@ -5,7 +5,6 @@
 """Test module for the server cache."""
 
 from pathlib import Path
-from tempfile import TemporaryDirectory
 
 from homcc.server.cache import Cache
 
@@ -13,34 +12,32 @@ from homcc.server.cache import Cache
 class TestCache:
     """Tests the server cache."""
 
-    def test_simple(self):
-        with TemporaryDirectory() as tmp_dir:
-            root_dir = Path(tmp_dir)
-            cache = Cache(root_dir, 1000)
-            cache_dir = root_dir / "cache"
+    def test_simple(self, tmp_path: Path):
+        cache = Cache(tmp_path, 1000)
+        cache_dir = tmp_path / "cache"
 
-            file1 = bytearray([0x1, 0x2, 0x3, 0x9])
-            cache.put("hash1", file1)
+        file1 = bytearray([0x1, 0x2, 0x3, 0x9])
+        cache.put("hash1", file1)
 
-            assert cache.get("hash1") == str(cache_dir / "hash1")
-            assert "hash1" in cache
-            assert Path.read_bytes(Path(cache.get("hash1"))) == file1
+        assert cache.get("hash1") == str(cache_dir / "hash1")
+        assert "hash1" in cache
+        assert Path.read_bytes(Path(cache.get("hash1"))) == file1
 
-            file2 = bytearray([0x3, 0x6, 0x3, 0x9])
-            cache.put("hash2", file2)
+        file2 = bytearray([0x3, 0x6, 0x3, 0x9])
+        cache.put("hash2", file2)
 
-            assert cache.get("hash2") == str(cache_dir / "hash2")
-            assert "hash2" in cache
-            assert Path.read_bytes(Path(cache.get("hash2"))) == file2
+        assert cache.get("hash2") == str(cache_dir / "hash2")
+        assert "hash2" in cache
+        assert Path.read_bytes(Path(cache.get("hash2"))) == file2
 
-            file3 = bytearray([0x4, 0x2])
-            cache.put("hash3", file3)
+        file3 = bytearray([0x4, 0x2])
+        cache.put("hash3", file3)
 
-            assert cache.get("hash3") == str(cache_dir / "hash3")
-            assert "hash3" in cache
-            assert Path.read_bytes(Path(cache.get("hash3"))) == file3
+        assert cache.get("hash3") == str(cache_dir / "hash3")
+        assert "hash3" in cache
+        assert Path.read_bytes(Path(cache.get("hash3"))) == file3
 
-            assert "other_hash" not in cache
+        assert "other_hash" not in cache
 
     @staticmethod
     def assert_hash_in_cache(cache: Cache, hash_value: str):
@@ -52,65 +49,63 @@ class TestCache:
         assert hash_value not in cache
         assert not (cache.cache_folder / hash_value).exists()
 
-    def test_eviction_size_limit(self):
-        with TemporaryDirectory() as tmp_dir:
-            cache = Cache(Path(tmp_dir), max_size_bytes=10)
+    def test_eviction_size_limit(self, tmp_path: Path):
+        cache = Cache(tmp_path, max_size_bytes=10)
 
-            cache.put("hash1", bytearray([0x1, 0x2, 0x3, 0x9]))
-            cache.put("hash2", bytearray([0x1, 0x2, 0x3, 0xA]))
-            cache.put("hash3", bytearray([0xFF, 0xFF]))
-            assert len(cache) == 3
-            self.assert_hash_in_cache(cache, "hash1")
-            self.assert_hash_in_cache(cache, "hash2")
-            self.assert_hash_in_cache(cache, "hash3")
+        cache.put("hash1", bytearray([0x1, 0x2, 0x3, 0x9]))
+        cache.put("hash2", bytearray([0x1, 0x2, 0x3, 0xA]))
+        cache.put("hash3", bytearray([0xFF, 0xFF]))
+        assert len(cache) == 3
+        self.assert_hash_in_cache(cache, "hash1")
+        self.assert_hash_in_cache(cache, "hash2")
+        self.assert_hash_in_cache(cache, "hash3")
 
-            cache.put("hash4", bytearray([0x1]))
-            assert len(cache) == 3
-            self.assert_hash_not_in_cache(cache, "hash1")
-            self.assert_hash_in_cache(cache, "hash2")
-            self.assert_hash_in_cache(cache, "hash3")
-            self.assert_hash_in_cache(cache, "hash4")
+        cache.put("hash4", bytearray([0x1]))
+        assert len(cache) == 3
+        self.assert_hash_not_in_cache(cache, "hash1")
+        self.assert_hash_in_cache(cache, "hash2")
+        self.assert_hash_in_cache(cache, "hash3")
+        self.assert_hash_in_cache(cache, "hash4")
 
-            cache.put("hash5", bytearray([0x1]))
-            assert len(cache) == 4
-            self.assert_hash_in_cache(cache, "hash2")
-            self.assert_hash_in_cache(cache, "hash3")
-            self.assert_hash_in_cache(cache, "hash4")
-            self.assert_hash_in_cache(cache, "hash5")
+        cache.put("hash5", bytearray([0x1]))
+        assert len(cache) == 4
+        self.assert_hash_in_cache(cache, "hash2")
+        self.assert_hash_in_cache(cache, "hash3")
+        self.assert_hash_in_cache(cache, "hash4")
+        self.assert_hash_in_cache(cache, "hash5")
 
-            cache.put("hash6", bytearray([0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9]))
-            assert len(cache) == 2
-            self.assert_hash_not_in_cache(cache, "hash2")
-            self.assert_hash_not_in_cache(cache, "hash3")
-            self.assert_hash_not_in_cache(cache, "hash4")
-            self.assert_hash_in_cache(cache, "hash5")
-            self.assert_hash_in_cache(cache, "hash6")
+        cache.put("hash6", bytearray([0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9]))
+        assert len(cache) == 2
+        self.assert_hash_not_in_cache(cache, "hash2")
+        self.assert_hash_not_in_cache(cache, "hash3")
+        self.assert_hash_not_in_cache(cache, "hash4")
+        self.assert_hash_in_cache(cache, "hash5")
+        self.assert_hash_in_cache(cache, "hash6")
 
-    def test_eviction_order_lru(self):
-        with TemporaryDirectory() as tmp_dir:
-            cache = Cache(Path(tmp_dir), max_size_bytes=10)
+    def test_eviction_order_lru(self, tmp_path: Path):
+        cache = Cache(tmp_path, max_size_bytes=10)
 
-            cache.put("hash1", bytearray([0x1, 0x2, 0x3, 0x9]))
-            cache.put("hash2", bytearray([0x1, 0x2, 0x3, 0xA]))
-            cache.put("hash3", bytearray([0xFF, 0xFF]))
-            assert len(cache) == 3
-            self.assert_hash_in_cache(cache, "hash1")
-            self.assert_hash_in_cache(cache, "hash2")
-            self.assert_hash_in_cache(cache, "hash3")
+        cache.put("hash1", bytearray([0x1, 0x2, 0x3, 0x9]))
+        cache.put("hash2", bytearray([0x1, 0x2, 0x3, 0xA]))
+        cache.put("hash3", bytearray([0xFF, 0xFF]))
+        assert len(cache) == 3
+        self.assert_hash_in_cache(cache, "hash1")
+        self.assert_hash_in_cache(cache, "hash2")
+        self.assert_hash_in_cache(cache, "hash3")
 
-            cache.get("hash1")  # make "hash1" the latest used element
-            cache.put("hash4", bytearray([0xFF, 0xFF, 0x0, 0x0]))
-            assert len(cache) == 3
-            self.assert_hash_not_in_cache(cache, "hash2")
-            self.assert_hash_in_cache(cache, "hash1")
-            self.assert_hash_in_cache(cache, "hash3")
-            self.assert_hash_in_cache(cache, "hash4")
+        cache.get("hash1")  # make "hash1" the latest used element
+        cache.put("hash4", bytearray([0xFF, 0xFF, 0x0, 0x0]))
+        assert len(cache) == 3
+        self.assert_hash_not_in_cache(cache, "hash2")
+        self.assert_hash_in_cache(cache, "hash1")
+        self.assert_hash_in_cache(cache, "hash3")
+        self.assert_hash_in_cache(cache, "hash4")
 
-            assert "hash3" in cache  # make "hash3" the latest used element
-            cache.put("hash5", bytearray([0xFF, 0xFF, 0x0, 0x0, 0xFF, 0xFF, 0x0, 0x0]))
-            assert len(cache) == 2
-            self.assert_hash_in_cache(cache, "hash3")
-            self.assert_hash_in_cache(cache, "hash5")
-            self.assert_hash_not_in_cache(cache, "hash1")
-            self.assert_hash_not_in_cache(cache, "hash2")
-            self.assert_hash_not_in_cache(cache, "hash4")
+        assert "hash3" in cache  # make "hash3" the latest used element
+        cache.put("hash5", bytearray([0xFF, 0xFF, 0x0, 0x0, 0xFF, 0xFF, 0x0, 0x0]))
+        assert len(cache) == 2
+        self.assert_hash_in_cache(cache, "hash3")
+        self.assert_hash_in_cache(cache, "hash5")
+        self.assert_hash_not_in_cache(cache, "hash1")
+        self.assert_hash_not_in_cache(cache, "hash2")
+        self.assert_hash_not_in_cache(cache, "hash4")

--- a/tests/server/environment_test.py
+++ b/tests/server/environment_test.py
@@ -135,9 +135,8 @@ class TestServerEnvironment:
         environment = create_mock_environment("", "")
         # pylint: disable=protected-access
         Cache._create_cache_folder = lambda *_: None  # type: ignore
-        cache = Cache(Path(""))
-        cache.cache = {"hash2": "some/path/to/be/linked"}
-
+        cache = Cache(Path(""), 1024)
+        cache.cache["hash2"] = "some/path/to/be/linked"
         needed_dependencies = environment.get_needed_dependencies(dependencies, cache)
 
         assert len(needed_dependencies) == 2


### PR DESCRIPTION
Implements an LRU eviction for the dependency cache. Cache size can be configured, and is per default 10G.

In a follow-up PR we can also abstract the cache and re-use it e.g. for object file caching. 