### PR TITLE
fix: whitespace in include arguments not handled properly for excluded dependency paths

### DIFF
--- a/.github/workflows/build-branch.yml
+++ b/.github/workflows/build-branch.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Execute isort
         uses: isort/isort-action@master
         with:
-          configuration: "--check --color --diff --gitignore --verbose"
+          configuration: "--check --diff --gitignore --verbose"
   tests:
     runs-on: ubuntu-22.04
     steps:

--- a/homcc/common/arguments.py
+++ b/homcc/common/arguments.py
@@ -499,7 +499,9 @@ class Arguments:
                         path: str = next(it) if arg == path_arg else arg[len(path_arg) :]
 
                         real_path: str = os.path.realpath(path)
-                        if not real_path.startswith(EXCLUDED_DEPENDENCY_PREFIXES):
+                        if real_path.startswith(EXCLUDED_DEPENDENCY_PREFIXES):
+                            arg = f"{path_arg}{real_path}"
+                        else:
                             arg = f"{path_arg}{self.map_path_arg(path, instance_path, mapped_cwd)}"
 
             else:

--- a/tests/server/environment_test.py
+++ b/tests/server/environment_test.py
@@ -61,7 +61,7 @@ class TestServerEnvironment:
         assert mapped_args.pop(0) == f"-isysroot{environment.instance_folder}/var/lib/sysroot.h"
         assert mapped_args.pop(0) == f"-o{environment.instance_folder}/home/user/output.o"
         assert mapped_args.pop(0) == f"-isystem{environment.instance_folder}/var/lib/system.h"
-        assert mapped_args.pop(0) == f"-isystem/usr/include/x86_64-linux-gnu/qt5"
+        assert mapped_args.pop(0) == "-isystem/usr/include/x86_64-linux-gnu/qt5"
         assert mapped_args.pop(0) == f"{environment.mapped_cwd}/main.cpp"
         assert mapped_args.pop(0) == f"{environment.mapped_cwd}/relative/relative.cpp"
         assert mapped_args.pop(0) == f"{environment.instance_folder}/opt/src/absolute.cpp"

--- a/tests/server/environment_test.py
+++ b/tests/server/environment_test.py
@@ -43,6 +43,8 @@ class TestServerEnvironment:
             "-isysroot/var/lib/sysroot.h",
             "-o/home/user/output.o",
             "-isystem/var/lib/system.h",
+            "-isystem",
+            "/usr/include/x86_64-linux-gnu/qt5",
             "main.cpp",
             "relative/relative.cpp",
             "/opt/src/absolute.cpp",
@@ -59,6 +61,7 @@ class TestServerEnvironment:
         assert mapped_args.pop(0) == f"-isysroot{environment.instance_folder}/var/lib/sysroot.h"
         assert mapped_args.pop(0) == f"-o{environment.instance_folder}/home/user/output.o"
         assert mapped_args.pop(0) == f"-isystem{environment.instance_folder}/var/lib/system.h"
+        assert mapped_args.pop(0) == f"-isystem/usr/include/x86_64-linux-gnu/qt5"
         assert mapped_args.pop(0) == f"{environment.mapped_cwd}/main.cpp"
         assert mapped_args.pop(0) == f"{environment.mapped_cwd}/relative/relative.cpp"
         assert mapped_args.pop(0) == f"{environment.instance_folder}/opt/src/absolute.cpp"
@@ -99,7 +102,7 @@ class TestServerEnvironment:
         assert mapped_args.pop(0) == f"{environment.mapped_cwd}/relative.cpp"
         assert mapped_args.pop(0) == "-c"
         assert mapped_args.pop(0) == f"{environment.mapped_cwd}/some_file.cpp"
-        assert mapped_args.pop(0) == "-I/usr/../usr/lib/../lib/libxml"
+        assert mapped_args.pop(0) == "-I/usr/lib/libxml"
 
     def test_map_cwd(self):
         instance_path = "/client1/"


### PR DESCRIPTION
Having quite a complex loop body, plus (manually) altering iterators is probably not the best idea.