### PR TITLE
fix: Do not `resolve` paths as this resolves symlinks

### DIFF
--- a/homcc/client/__init__.py
+++ b/homcc/client/__init__.py
@@ -4,4 +4,4 @@
 
 """HOMCC client: homcc"""
 
-__version__: str = "1.0.1"
+__version__: str = "1.0.2"

--- a/homcc/client/compilation.py
+++ b/homcc/client/compilation.py
@@ -259,11 +259,11 @@ def find_dependencies(arguments: Arguments) -> Set[str]:
     def extract_dependencies(line: str) -> List[str]:
         split: List[str] = line.split(":")  # remove preprocessor output targets specified via -MT
         dependency_line: str = split[1] if len(split) == 2 else split[0]  # e.g. ignore "foo.o bar.o:"
-        return [dependency for dependency in dependency_line.rstrip("\\").split()]  # remove line break char "\"
+        return list(dependency_line.rstrip("\\").split())  # remove line break char "\"
 
     # extract dependencies from the preprocessor result and filter for sendability
     return {
-        dependency
+        str(Path(dependency).absolute())
         for line in dependency_result.splitlines()
         for dependency in extract_dependencies(line)
         if not dependency.startswith(EXCLUDED_DEPENDENCY_PREFIXES)  # check sendability

--- a/homcc/client/compilation.py
+++ b/homcc/client/compilation.py
@@ -262,7 +262,7 @@ def find_dependencies(arguments: Arguments) -> Set[str]:
         return [
             str(Path(dependency).absolute())  # Always work with absolute paths
             for dependency in dependency_line.rstrip("\\").split()  # remove line break char "\"
-        ]  # remove line break char "\"
+        ]
 
     # extract dependencies from the preprocessor result and filter for sendability
     return {

--- a/homcc/client/compilation.py
+++ b/homcc/client/compilation.py
@@ -259,14 +259,17 @@ def find_dependencies(arguments: Arguments) -> Set[str]:
     def extract_dependencies(line: str) -> List[str]:
         split: List[str] = line.split(":")  # remove preprocessor output targets specified via -MT
         dependency_line: str = split[1] if len(split) == 2 else split[0]  # e.g. ignore "foo.o bar.o:"
-        return list(dependency_line.rstrip("\\").split())  # remove line break char "\"
+        return [
+            str(Path(dependency).absolute())  # Always work with absolute paths
+            for dependency in dependency_line.rstrip("\\").split()  # remove line break char "\"
+        ]  # remove line break char "\"
 
     # extract dependencies from the preprocessor result and filter for sendability
     return {
-        str(Path(dependency).absolute())
+        dependency
         for line in dependency_result.splitlines()
         for dependency in extract_dependencies(line)
-        if not dependency.startswith(EXCLUDED_DEPENDENCY_PREFIXES)  # check sendability
+        if not str(Path(dependency).resolve()).startswith(EXCLUDED_DEPENDENCY_PREFIXES)  # check sendability
     }
 
 

--- a/homcc/client/compilation.py
+++ b/homcc/client/compilation.py
@@ -259,10 +259,7 @@ def find_dependencies(arguments: Arguments) -> Set[str]:
     def extract_dependencies(line: str) -> List[str]:
         split: List[str] = line.split(":")  # remove preprocessor output targets specified via -MT
         dependency_line: str = split[1] if len(split) == 2 else split[0]  # e.g. ignore "foo.o bar.o:"
-        return [
-            str(Path(dependency).resolve())  # normalize paths, e.g. convert /usr/bin/../lib/ to /usr/lib/
-            for dependency in dependency_line.rstrip("\\").split()  # remove line break char "\"
-        ]
+        return [dependency for dependency in dependency_line.rstrip("\\").split()]  # remove line break char "\"
 
     # extract dependencies from the preprocessor result and filter for sendability
     return {

--- a/homcc/common/arguments.py
+++ b/homcc/common/arguments.py
@@ -498,7 +498,7 @@ class Arguments:
                     if arg.startswith(path_arg):
                         path: str = next(it) if arg == path_arg else arg[len(path_arg) :]
 
-                        real_path: str = os.path.realpath(path)
+                        real_path: str = str(Path(path).resolve())
                         if real_path.startswith(EXCLUDED_DEPENDENCY_PREFIXES):
                             arg = f"{path_arg}{real_path}"
                         else:

--- a/homcc/server/__init__.py
+++ b/homcc/server/__init__.py
@@ -4,4 +4,4 @@
 
 """HOMCC server: homccd"""
 
-__version__: str = "1.0.1"
+__version__: str = "1.0.2"

--- a/homcc/server/cache.py
+++ b/homcc/server/cache.py
@@ -63,8 +63,8 @@ class Cache:
             oldest_path.unlink(missing_ok=False)
         except FileNotFoundError:
             logger.error(
-                """Tried to evict cache entry with hash '%s', but corresponding cache file at '%s' did not exist. 
-                This may lead to an invalid cache size calculation.""",
+                """Tried to evict cache entry with hash '%s', but corresponding cache file at '%s' did not exist.
+                 This may lead to an invalid cache size calculation.""",
                 oldest_hash,
                 oldest_path,
             )

--- a/homcc/server/parsing.py
+++ b/homcc/server/parsing.py
@@ -198,9 +198,9 @@ class ServerConfig:
             address=address,
             log_level=log_level,
             verbose=verbose,
-            max_dependency_cache_size_bytes=None
-            if max_dependency_cache_size is None
-            else size_string_to_bytes(max_dependency_cache_size),
+            max_dependency_cache_size_bytes=(
+                None if max_dependency_cache_size is None else size_string_to_bytes(max_dependency_cache_size)
+            ),
         )
 
     def __str__(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ sysv_ipc==1.0.0 # see https://packages.ubuntu.com/jammy/python3-sysv-ipc
 black==22.6.0
 isort[colors]
 mypy==0.990
-pylint=2.14.4
+pylint==2.14.4
 PySide2~=5.15
 pytest
 pytest-asyncio

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,10 +2,10 @@ python-lzo==1.12 # see https://packages.ubuntu.com/jammy/python3-lzo
 sysv_ipc==1.0.0 # see https://packages.ubuntu.com/jammy/python3-sysv-ipc
 
 # test, CI, package, formatting, linting, ...
-black
+black==22.6.0
 isort[colors]
 mypy==0.990
-pylint
+pylint=2.14.4
 PySide2~=5.15
 pytest
 pytest-asyncio

--- a/tests/client/client_test.py
+++ b/tests/client/client_test.py
@@ -2,7 +2,7 @@
 # Covered under the included MIT License:
 #   https://github.com/celonis/homcc/blob/main/LICENSE
 
-""" Tests for client/client.py"""
+"""Tests for client/client.py"""
 
 import os
 import threading

--- a/tests/client/compilation_test.py
+++ b/tests/client/compilation_test.py
@@ -2,7 +2,7 @@
 # Covered under the included MIT License:
 #   https://github.com/celonis/homcc/blob/main/LICENSE
 
-""" Tests for client/compilation.py"""
+"""Tests for client/compilation.py"""
 import os
 import subprocess
 from pathlib import Path

--- a/tests/client/parsing_test.py
+++ b/tests/client/parsing_test.py
@@ -2,7 +2,7 @@
 # Covered under the included MIT License:
 #   https://github.com/celonis/homcc/blob/main/LICENSE
 
-""" Tests for client/parsing.py"""
+"""Tests for client/parsing.py"""
 import os
 import subprocess
 from pathlib import Path

--- a/tests/common/compression_test.py
+++ b/tests/common/compression_test.py
@@ -2,7 +2,7 @@
 # Covered under the included MIT License:
 #   https://github.com/celonis/homcc/blob/main/LICENSE
 
-""" Tests for common/compression.py"""
+"""Tests for common/compression.py"""
 from homcc.common.compression import LZMA, LZO, CompressedBytes, NoCompression
 
 TEST_DATA: bytearray = bytearray([0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x6, 0x6, 0x9])

--- a/tests/server/parsing_test.py
+++ b/tests/server/parsing_test.py
@@ -2,7 +2,7 @@
 # Covered under the included MIT License:
 #   https://github.com/celonis/homcc/blob/main/LICENSE
 
-"""Tests for client/compilation.py"""
+"""Tests for server/parsing.py"""
 import os
 from argparse import ArgumentTypeError
 from pathlib import Path

--- a/tests/server/parsing_test.py
+++ b/tests/server/parsing_test.py
@@ -2,7 +2,7 @@
 # Covered under the included MIT License:
 #   https://github.com/celonis/homcc/blob/main/LICENSE
 
-""" Tests for client/compilation.py"""
+"""Tests for client/compilation.py"""
 import os
 from argparse import ArgumentTypeError
 from pathlib import Path


### PR DESCRIPTION
If the source contains symlinked files resolving the dependencies will fail as the path is then not the path of the symlink (which is assumed in includes) but the resolved path. 
Removing the `..` from paths is only a side-effect of `resolve`. I think we don't stricly need it anyways.