### PR TITLE
build: fail fast in deb Makefile and allow overriding the Python interpreter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,12 @@
 .ONESHELL:
+# abort a recipe as soon as any command fails instead of limping on to later steps;
+# without this a failing `sdist_dsc` (e.g. missing/incompatible stdeb) is masked by a
+# confusing "debian/changelog missing" error from dpkg-buildpackage running in the wrong directory
+.SHELLFLAGS := -ec
+
+# interpreter used to run the stdeb build; override for a Python that has a working stdeb,
+# e.g. `make PYTHON=python3.11 all` (stdeb 0.10.0 does not run on Python 3.12+)
+PYTHON ?= python3
 
 all: server client
 
@@ -8,7 +16,7 @@ server:
 	echo "Building the homcc server .deb"
 
 	cp setup_server.py setup.py
-	python3 setup.py --command-packages=stdeb.command sdist_dsc --with-dh-systemd
+	$(PYTHON) setup.py --command-packages=stdeb.command sdist_dsc --with-dh-systemd
 
 	echo "-- Copying service file"
 	# we need to copy the systemd service file to the generated package
@@ -31,7 +39,7 @@ client:
 	echo "Building the homcc client .deb"
 
 	cp setup_client.py setup.py
-	python3 setup.py --command-packages=stdeb.command sdist_dsc
+	$(PYTHON) setup.py --command-packages=stdeb.command sdist_dsc
 
 	cd deb_dist/homcc-*
 	cp $(DEBIAN_SRC)/compat debian/compat


### PR DESCRIPTION
## Problem

Running `make` to build the `.deb` packages fails with a misleading **`debian/changelog` missing** error. That is a *downstream symptom*, not the root cause.

The `debian/changelog` (and the rest of the package's `debian/` tree) is generated by `stdeb`'s `sdist_dsc` step. That step is what actually fails — but the recipes use `.ONESHELL:` **without** `set -e`, so on failure the recipe keeps going: `cd deb_dist/<pkg>-*` silently no-ops (the glob never matches), and `dpkg-buildpackage` then runs in the **repo root**, whose `debian/` has only `compat` + `homccd.service` and no `changelog`. Hence the confusing error.

`sdist_dsc` fails for environment reasons such as:
- the `python3` that `make` invokes not having `stdeb` installed (`error: invalid command 'sdist_dsc'`), or
- `stdeb 0.10.0` being incompatible with **Python 3.12+** (`AttributeError: module 'configparser' has no attribute 'SafeConfigParser'`).

## Fix

Makefile hardening only — surface the real failure and make the interpreter selectable:

- `.SHELLFLAGS := -ec` so recipes abort at the first failing command instead of limping into the changelog error.
- `PYTHON ?= python3`, used for both `sdist_dsc` calls, so the build can target an interpreter with a working stdeb, e.g. `make PYTHON=python3.11 all`.

## Notes

- This does not itself make `stdeb` work on Python 3.12; producing `.deb`s still requires an interpreter ≤ 3.11 with a working stdeb (or a jammy build environment as the README assumes). The build now reports that clearly rather than masking it.
- No behavior change to a working build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)